### PR TITLE
SEO : Création d'un environnement pour le rendu des tags SEO

### DIFF
--- a/src/ContentManagement/Domain/Seo/Factory/PageFactory.php
+++ b/src/ContentManagement/Domain/Seo/Factory/PageFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Factory;
+
+use App\ContentManagement\Domain\Seo\Model\MetaName;
+use App\ContentManagement\Domain\Seo\Model\OpenGraph;
+use App\ContentManagement\Domain\Seo\Model\Page;
+use App\ContentManagement\Domain\Seo\Model\Title;
+use Library\Assert\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class PageFactory
+{
+    protected Request $request;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->request = $requestStack->getCurrentRequest();
+    }
+
+    /**
+     * Creates a new page with default configuration properties.
+     * *title* and *description* are required.
+     */
+    public function create(Title $title, array $nameMeta, array $openGraph): Page
+    {
+        Assert::allIsInstanceOf($nameMeta, MetaName\Meta::class);
+        Assert::allIsInstanceOf($openGraph, OpenGraph\Meta::class);
+        
+        return new Page(
+            title: $title,
+            openGraphMeta: [...$openGraph, ...$this->defaultOGMeta()],
+            nameMeta: [...$nameMeta, ...$this->defaultNameMeta()],
+        );
+    }
+
+    private function defaultNameMeta(): array
+    {
+        return [
+            MetaName\Viewport::new('width=device-width, initial-scale=1, shrink-to-fit=no')
+        ];
+    }
+
+    private function defaultOGMeta(): array
+    {
+        return [
+            OpenGraph\Type::new('website'),
+            OpenGraph\Locale::new('fr_fr'),
+            OpenGraph\Url::new($this->request->getUri()),
+            OpenGraph\SiteName::new('www.MyBicycleJourney.com'),
+        ];
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/ApplicationName.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/ApplicationName.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+/**
+ * The name of the application running in the web page.
+ */
+class ApplicationName extends Meta
+{
+    private const PROPERTY = 'application-name';
+
+    public static function new(string $content): ApplicationName
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Author.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Author.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+/**
+ * The name of the document's author.
+ */
+class Author extends Meta
+{
+    private const PROPERTY = 'author';
+
+    public static function new(string $content): Author
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Description.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Description.php
@@ -3,13 +3,17 @@
 namespace App\ContentManagement\Domain\Seo\Model\MetaName;
 
 /**
- * A short and accurate summary of the content of the page. 
+ * A short and accurate summary of the content of the page.
  * Several browsers, like Firefox and Opera, use this as the default description of bookmarked pages.
  */
 class Description extends Meta
 {
     private const PROPERTY = 'description';
 
+    /**
+     * The recommended meta description length is 920 pixels
+     * or roughly 155 characters or less including spaces
+     */
     public static function new(string $content): Description
     {
         return new self(self::PROPERTY, $content);

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Description.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Description.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+/**
+ * A short and accurate summary of the content of the page. 
+ * Several browsers, like Firefox and Opera, use this as the default description of bookmarked pages.
+ */
+class Description extends Meta
+{
+    private const PROPERTY = 'description';
+
+    public static function new(string $content): Description
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Generator.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Generator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+/**
+ * The identifier of the software that generated the page.
+ */
+class Generator extends Meta
+{
+    private const PROPERTY = 'generator';
+
+    public static function new(string $content): Generator
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Keywords.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Keywords.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+/**
+ * Words relevant to the page's content separated by commas.
+ */
+class Keywords extends Meta
+{
+    private const PROPERTY = 'keywords';
+
+    public static function new(iterable $values): Keywords
+    {
+        return new self(self::PROPERTY, implode(', ', $values));
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Meta.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Meta.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+/**
+ * The basic meta tag, used on every website to indicate primary information.
+ * 
+ * The <meta> element can be used to provide document metadata in terms of name-value 
+ * pairs, with the name attribute giving the metadata name,
+ * and the content attribute giving the value.
+ *
+ * @see https://developer.mozilla.org/en/docs/Web/HTML/Element/meta#attr-name
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name
+ */
+abstract class Meta
+{
+    private string $type;
+    private string $content;
+
+    public function __construct(string $type, string $content)
+    {
+        $this->type = $type;
+        $this->content = $content;
+    }
+    
+    public function render(): string
+    {
+        return sprintf(
+            '<meta name="%s" content="%S">',
+            $this->type, $this->content
+        );
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Meta.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Meta.php
@@ -23,10 +23,10 @@ abstract class Meta
         $this->content = $content;
     }
     
-    public function render(): string
+    public function __toString(): string
     {
         return sprintf(
-            '<meta name="%s" content="%S">',
+            '<meta name="%s" content="%s">',
             $this->type, $this->content
         );
     }

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Referrer.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Referrer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+use Library\Assert\Assert;
+
+/**
+ * Controls the HTTP Referer header of requests sent from the document.
+ */
+class Referrer extends Meta
+{
+    private const PROPERTY = 'referrer';
+    
+    public static function new(string $content): Referrer
+    {
+        Assert::oneOf($content, self::availableValues());
+
+        return new self(self::PROPERTY, $content);
+    }
+
+    private static function availableValues(): array
+    {
+        return [
+            // Do not send a HTTP Referer header.
+            'no-referrer',
+
+            // Send the origin of the document.
+            'origin',
+
+            // Send the full URL when the destination is at least as secure as the current page (HTTP(S)→HTTPS),
+            // but send no referrer when it's less secure (HTTPS→HTTP). This is the default behavior.
+            'no-referrer-when-downgrade',
+
+            // Send the full URL (stripped of parameters) for same-origin requests,
+            // but only send the origin for other cases.
+            'origin-when-cross-origin',
+
+            // Send the full URL (stripped of parameters) for same-origin requests.
+            // Cross-origin requests will contain no referrer header.
+            'same-origin',
+
+            // Send the origin when the destination is at least as secure as the current page (HTTP(S)→HTTPS),
+            // but send no referrer when it's less secure (HTTPS→HTTP).
+            'strict-origin',
+
+            // Send the full URL (stripped of parameters) for same-origin requests.
+            // Send the origin when the destination is at least as secure as the current page (HTTP(S)→HTTPS).
+            // Otherwise, send no referrer.
+            'strict-origin-when-cross-origin',
+
+            // Send the full URL (stripped of parameters) for same-origin or cross-origin requests.
+            'unsafe-URL',
+        ];
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Robots.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Robots.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+use Library\Assert\Assert;
+
+/**
+ * The behavior that cooperative crawlers, or "robots", should use with the page.
+ * It is a comma-separated list of the values below.
+ */
+class Robots extends Meta
+{
+    private const PROPERTY = 'robots';
+
+    public static function new(array $values): Robots
+    {
+        Assert::allIsAnyOf($values, self::availableValues());
+
+        return new self(self::PROPERTY, implode(', ', $values));
+    }
+
+    private static function availableValues(): array
+    {
+        return [
+            // Allows the robot to index the page (default).
+            // Used by: All
+            'index',
+
+            // Requests the robot to not index the page.
+            // Used by: All
+            'noindex',
+
+            // Allows the robot to follow the links on the page (default).
+            // Used by: All
+            'follow',
+
+            // Requests the robot to not follow the links on the page.
+            // Used by: All
+            'nofollow',
+
+            // Equivalent to index, follow
+            // Used by: Google
+            'all',
+
+            // Equivalent to noindex, nofollow
+            // Used by: Google
+            'none',
+
+            // Requests the search engine not to cache the page content.
+            // Used by: Google, Yahoo, Bing
+            'noarchive',
+
+            // Prevents displaying any description of the page in search engine results.
+            // Used by: Google, Bing
+            'nosnippet',
+
+            // Requests this page not to appear as the referring page of an indexed image.
+            // Used by: Google
+            'noimageindex',
+
+            // Synonym of noarchive.
+            // Used by: Bing
+            'nocache',
+        ];
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/MetaName/Viewport.php
+++ b/src/ContentManagement/Domain/Seo/Model/MetaName/Viewport.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\MetaName;
+
+/**
+ * The browser's viewport is the area of the window in which web content 
+ * can be seen. This is often not the same size as the rendered page, 
+ * in which case the browser provides scrollbars for the user to scroll 
+ * around and access all the content.
+ */
+class Viewport extends Meta
+{
+    private const PROPERTY = 'viewport';
+
+    public static function new(string $content): Viewport
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Description.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Description.php
@@ -2,6 +2,8 @@
 
 namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
 
+use Library\Assert\Assert;
+
 /**
  * A one to two sentence description of your object.
  */
@@ -11,6 +13,10 @@ class Description extends Meta
 
     public static function new(string $content): Description
     {
+        // The recommended meta description length is 920 pixels
+        // or roughly 155 characters or less including spaces 
+        Assert::maxLength($content, 160);
+
         return new self(self::PROPERTY, $content);
     }
 }

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Description.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Description.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * A one to two sentence description of your object.
+ */
+class Description extends Meta
+{
+    private const PROPERTY = 'description';
+
+    public static function new(string $content): Description
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Description.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Description.php
@@ -2,8 +2,6 @@
 
 namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
 
-use Library\Assert\Assert;
-
 /**
  * A one to two sentence description of your object.
  */
@@ -11,12 +9,11 @@ class Description extends Meta
 {
     private const PROPERTY = 'description';
 
+    /**
+     * SEO experts recommend that you do not go beyond the limit of 200 characters.
+     */
     public static function new(string $content): Description
     {
-        // The recommended meta description length is 920 pixels
-        // or roughly 155 characters or less including spaces 
-        Assert::maxLength($content, 160);
-
         return new self(self::PROPERTY, $content);
     }
 }

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Image.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Image.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * An image URL which should represent your object within the graph.
+ */
+class Image extends Meta
+{
+    private const PROPERTY = 'image';
+
+    public static function new(string $content): Image
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Locale.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Locale.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * The locale these tags are marked up in. Of the format language_TERRITORY. 
+ * Default is en_US.
+ */
+class Locale extends Meta
+{
+    private const PROPERTY = 'locale';
+
+    public static function new(string $content): Locale
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Meta.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Meta.php
@@ -20,10 +20,10 @@ abstract class Meta
         $this->content = $content;
     }
     
-    public function render(): string
+    public function __toString(): string
     {
         return sprintf(
-            '<meta property="og:%s" content="%S">',
+            '<meta property="og:%s" content="%s">',
             $this->property, $this->content
         );
     }

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Meta.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Meta.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * The Open Graph protocol enables any web page to become a rich object
+ * in a social graph. For instance, this is used on Facebook to allow any
+ * web page to have the same functionality as any other object on Facebook.
+ *
+ * @see https://ogp.me/
+ */
+abstract class Meta
+{
+    private string $property;
+    private string $content;
+
+    public function __construct(string $property, string $content)
+    {
+        $this->property = $property;
+        $this->content = $content;
+    }
+    
+    public function render(): string
+    {
+        return sprintf(
+            '<meta property="og:%s" content="%S">',
+            $this->property, $this->content
+        );
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/SiteName.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/SiteName.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * If your object is part of a larger website, 
+ * the name which should be displayed for the overall site. e.g., "IMDb".
+ */
+class SiteName extends Meta
+{
+    private const PROPERTY = 'site_name';
+
+    public static function new(string $content): SiteName
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Title.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Title.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * The title of your object as it should appear within the graph, e.g., "The Rock".
+ */
+class Title extends Meta
+{
+    private const PROPERTY = 'title';
+
+    public static function new(string $content): Title
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Type.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Type.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * The type of your object, e.g., "video.movie". 
+ * Depending on the type you specify, other properties may also be required.
+ * 
+ * @see https://ogp.me/#types
+ */
+class Type extends Meta
+{
+    private const PROPERTY = 'type';
+
+    public static function new(string $content): Type
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/OpenGraph/Url.php
+++ b/src/ContentManagement/Domain/Seo/Model/OpenGraph/Url.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model\OpenGraph;
+
+/**
+ * The canonical URL of your object that will be used as its 
+ * permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/".
+ */
+class Url extends Meta
+{
+    private const PROPERTY = 'url';
+
+    public static function new(string $content): Url
+    {
+        return new self(self::PROPERTY, $content);
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/Page.php
+++ b/src/ContentManagement/Domain/Seo/Model/Page.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model;
+
+/**
+ * Brings together all the resources required to for rendering SEO tags. 
+ */
+class Page
+{
+    private string $title;
+
+    /**
+     * @var array<OpenGraph\Meta>
+     */
+    private array $openGraphMeta;
+
+    /**
+     * @var array<MetaName\Meta>
+     */
+    private array $metaNames;
+
+    public function __construct(
+        string $title,
+        array  $openGraphMeta,
+        array  $metaNames
+    )
+    {
+        $this->title = $title;
+        $this->openGraphMeta = $openGraphMeta;
+        $this->metaNames = $metaNames;
+    }
+}

--- a/src/ContentManagement/Domain/Seo/Model/Page.php
+++ b/src/ContentManagement/Domain/Seo/Model/Page.php
@@ -17,16 +17,49 @@ class Page
     /**
      * @var array<MetaName\Meta>
      */
-    private array $metaNames;
+    private array $nameMeta;
 
     public function __construct(
         Title $title,
-        array $openGraphMeta,
-        array $metaNames
+        array $openGraphMeta = [],
+        array $nameMeta = []
     )
     {
         $this->title = $title;
         $this->openGraphMeta = $openGraphMeta;
-        $this->metaNames = $metaNames;
+        $this->nameMeta = $nameMeta;
+    }
+
+    public function title(): Title
+    {
+        return $this->title;
+    }
+
+    public function addOGMeta(OpenGraph\Meta $meta): self
+    {
+        $this->openGraphMeta[] = $meta;
+        return $this;
+    }
+    
+    public function addNameMeta(OpenGraph\Meta $meta): self
+    {
+        $this->openGraphMeta[] = $meta;
+        return $this;
+    }
+
+    /**
+     * @return OpenGraph\Meta[]
+     */
+    public function openGraph(): array
+    {
+        return $this->openGraphMeta;
+    }
+
+    /**
+     * @return MetaName\Meta[]
+     */
+    public function nameMeta(): array
+    {
+        return $this->nameMeta;
     }
 }

--- a/src/ContentManagement/Domain/Seo/Model/Page.php
+++ b/src/ContentManagement/Domain/Seo/Model/Page.php
@@ -3,11 +3,11 @@
 namespace App\ContentManagement\Domain\Seo\Model;
 
 /**
- * Brings together all the resources required to for rendering SEO tags. 
+ * Brings together all the resources required for rendering SEO tags.
  */
 class Page
 {
-    private string $title;
+    private Title $title;
 
     /**
      * @var array<OpenGraph\Meta>
@@ -20,9 +20,9 @@ class Page
     private array $metaNames;
 
     public function __construct(
-        string $title,
-        array  $openGraphMeta,
-        array  $metaNames
+        Title $title,
+        array $openGraphMeta,
+        array $metaNames
     )
     {
         $this->title = $title;

--- a/src/ContentManagement/Domain/Seo/Model/Title.php
+++ b/src/ContentManagement/Domain/Seo/Model/Title.php
@@ -2,10 +2,8 @@
 
 namespace App\ContentManagement\Domain\Seo\Model;
 
-use Library\Assert\Assert;
-
 /**
- * The title tag defines the title of the document. The title must be text-only, 
+ * The title tag defines the title of the document. The title must be text-only,
  * and it is shown in the browser's title bar or in the page's tab.
  */
 class Title
@@ -17,15 +15,15 @@ class Title
         $this->value = $value;
     }
 
+    /**
+     *  According to some research on popular websites,
+     * the title length is always between 50 & 80 characters.
+     */
     public static function new(string $value): Title
     {
-        // According to some research on popular websites, 
-        // the title length is always between 50 & 80 characters.
-        Assert::lengthBetween($value, 50, 80);
-        
         return new self($value);
     }
-    
+
     public function __toString(): string
     {
         return $this->value;

--- a/src/ContentManagement/Domain/Seo/Model/Title.php
+++ b/src/ContentManagement/Domain/Seo/Model/Title.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\ContentManagement\Domain\Seo\Model;
+
+use Library\Assert\Assert;
+
+/**
+ * The title tag defines the title of the document. The title must be text-only, 
+ * and it is shown in the browser's title bar or in the page's tab.
+ */
+class Title
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function new(string $value): Title
+    {
+        // According to some research on popular websites, 
+        // the title length is always between 50 & 80 characters.
+        Assert::lengthBetween($value, 50, 80);
+        
+        return new self($value);
+    }
+    
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/ContentManagement/Ui/Pages/Web/Controller/HomepageController.php
+++ b/src/ContentManagement/Ui/Pages/Web/Controller/HomepageController.php
@@ -2,6 +2,8 @@
 
 namespace App\ContentManagement\Ui\Pages\Web\Controller;
 
+use App\ContentManagement\Domain\Seo\Factory\PageFactory;
+use App\ContentManagement\Domain\Seo\Model\Title;
 use App\ContentManagement\Ui\Pages\Web\Form\RegisterEarlyBirdType;
 use App\Marketing\Application\Launch\Command\RegisterEarlyBird;
 use App\Marketing\Domain\Launch\Exception\EmailIsAlreadyRegistered;
@@ -10,13 +12,16 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use App\ContentManagement\Domain\Seo\Model\OpenGraph;
+use App\ContentManagement\Domain\Seo\Model\MetaName;
 
 #[Route('/', name: 'homepage')]
 class HomepageController extends AbstractController
 {
     public function __invoke(
-        Request    $request,
-        CommandBus $commandBus
+        Request     $request,
+        CommandBus  $commandBus,
+        PageFactory $pageFactory
     ): Response
     {
         $command = new RegisterEarlyBird();
@@ -33,8 +38,20 @@ class HomepageController extends AbstractController
             }
         }
 
+        $seo = $pageFactory->create(
+            title: Title::new("L'aventure commence ici ! | My Bicycle Journey"),
+            nameMeta: [
+                MetaName\Description::new("Raconte nous tes plus beaux périples à vélo, le plus simplement du monde. Tu n'as plus qu'à profiter de la route, désormais 5 minutes au bivouac te suffiront pour envoyer des nouvelles à tes proches."),
+            ],
+            openGraph: [
+                OpenGraph\Title::new("Partage tes plus belles aventures à vélo, en toute simplicité."),
+                OpenGraph\Description::new("Raconte nous tes plus beaux périples à vélo, le plus simplement du monde. Tu n'as plus qu'à profiter de la route, désormais 5 minutes au bivouac te suffiront pour envoyer des nouvelles à tes proches."),
+            ]
+        );
+
         return $this->render('web/pages/homepage/index.html.twig', [
-            'form' => $form->createView()
+            'form' => $form->createView(),
+            'seo' => $seo
         ]);
     }
 }

--- a/src/ContentManagement/Ui/Pages/Web/Controller/TheProjectController.php
+++ b/src/ContentManagement/Ui/Pages/Web/Controller/TheProjectController.php
@@ -2,6 +2,10 @@
 
 namespace App\ContentManagement\Ui\Pages\Web\Controller;
 
+use App\ContentManagement\Domain\Seo\Factory\PageFactory;
+use App\ContentManagement\Domain\Seo\Model\OpenGraph;
+use App\ContentManagement\Domain\Seo\Model\MetaName;
+use App\ContentManagement\Domain\Seo\Model\Title;
 use App\ContentManagement\Ui\Pages\Web\Form\RegisterEarlyBirdType;
 use App\Marketing\Application\Launch\Command\RegisterEarlyBird;
 use App\Marketing\Domain\Launch\Exception\EmailIsAlreadyRegistered;
@@ -11,15 +15,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-#[Route(
-    path: ['en' => '/the-project', 'fr' => '/le-projet'], 
-    name: 'the_project'
-)]
+#[Route('/le-projet', name: 'the_project')]
 class TheProjectController extends AbstractController
 {
     public function __invoke(
-        Request    $request,
-        CommandBus $commandBus
+        Request     $request,
+        CommandBus  $commandBus,
+        PageFactory $pageFactory
     ): Response
     {
         $command = new RegisterEarlyBird();
@@ -35,9 +37,20 @@ class TheProjectController extends AbstractController
                 $this->addFlash('success', 'Ton email est déjà enregistré, mais promis on ne t\'oublie pas 👊');
             }
         }
+        $seo = $pageFactory->create(
+            title: Title::new("Découvre le projet | My Bicycle Journey"),
+            nameMeta: [
+                MetaName\Description::new("Un peu plus qu'un site, MBJ c'est avant tout une aventure en soi. Viens découvrir le projet et pourquoi pas y prendre part ?"),
+            ],
+            openGraph: [
+                OpenGraph\Title::new("Découvre le projet My Bicycle Journey."),
+                OpenGraph\Description::new("Un peu plus qu'un site, MBJ c'est avant tout une aventure en soi. Viens découvrir le projet et pourquoi pas y prendre part ?"),
+            ]
+        );
 
         return $this->render('web/pages/the_project/index.html.twig', [
-            'form' => $form->createView()
+            'form' => $form->createView(),
+            'seo' => $seo
         ]);
     }
 }

--- a/templates/web/base.html.twig
+++ b/templates/web/base.html.twig
@@ -1,20 +1,18 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <title>{% block title %}My Bicycle Journey{% endblock %}</title>
-
-        <link rel="icon" href="{{ asset('build/images/favicon.ico') }}" sizes="any">
-        <link rel="apple-touch-icon" href="{{ asset('build/images/apple-touch-icon.png') }}">
-
+        {% include 'web/shared/_seo.html.twig' %}
+        
         {% block stylesheets %}
             {{ encore_entry_link_tags('app') }}
         {% endblock %}
-
+        
         {% block javascripts %}
             {{ encore_entry_script_tags('app') }}
         {% endblock %}
+
+        <link rel="icon" href="{{ asset('build/images/favicon.ico') }}" sizes="any">
+        <link rel="apple-touch-icon" href="{{ asset('build/images/apple-touch-icon.png') }}">
     </head>
     <body>
         {% include 'web/shared/_flash_messages.html.twig' %}

--- a/templates/web/shared/_seo.html.twig
+++ b/templates/web/shared/_seo.html.twig
@@ -1,0 +1,25 @@
+{# @seo \App\ContentManagement\Domain\Seo\Model\Page #}
+
+{% block title %}
+    <title>{{ seo.title ?? 'My Bycicle Journey' }}</title>
+{% endblock %}
+
+{% block sharedMeta %}
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Language" content="fr_fr">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+{% endblock %}
+
+{% block metaNames %}
+    {% for meta in seo.nameMeta %}
+        {{ meta | raw }}
+    {% endfor %}
+{% endblock %}
+
+{% block openGraph %}
+    {% for meta in seo.openGraph %}
+        {{ meta | raw}}
+    {% endfor %}
+{% endblock %}
+
+


### PR DESCRIPTION
## Description    
Cette PR ajoute un système de gestion de balises meta, necessaire pour le SEO.

## TODO
- [x] Ajouter un `VO`s pour `Title` avec une contrainte sur le nombre de caractères
- [x] Ajouter une contrainte sur le nombre de caractères de la description
- [x] Créer une factory pour rendre un objet `Page` avec la configuration de base
- [x] Créer les configurations pour les pages `homepage` & `the_project`
- [x] Gérer le rendu en twig